### PR TITLE
Add Phase1 health audit endpoint and enforce tenant-scoped updates/deletes for posts

### DIFF
--- a/Server/routes/healthRoutes.ts
+++ b/Server/routes/healthRoutes.ts
@@ -6,6 +6,8 @@
 import { Router, Request, Response } from "express";
 import db from "../db.js";
 import os from "os";
+import fs from "fs";
+import path from "path";
 
 const router = Router();
 
@@ -157,6 +159,63 @@ router.get("/db", async (_req: Request, res: Response) => {
       error:     err.message,
     });
   }
+});
+
+// ─── GET /health/phase1 — Core Engine Completion Audit ───────────────────────
+
+router.get("/phase1", async (_req: Request, res: Response) => {
+  const checks = {
+    rlsMigration: false,
+    gdprMigration: false,
+    backupWorkflow: false,
+    securityDeps: false,
+    requiredEnv: false,
+    dbReachable: false,
+  };
+
+  const projectRoot = process.cwd();
+  const rlsMigrationPath = path.join(projectRoot, "prisma", "migrations", "20260223210000_phase1_rls_policies", "migration.sql");
+  const gdprMigrationPath = path.join(projectRoot, "prisma", "migrations", "add_gdpr_privacy_ack", "migration.sql");
+  const backupWorkflowPath = path.join(projectRoot, ".github", "workflows", "db-backup.yml");
+
+  checks.rlsMigration = fs.existsSync(rlsMigrationPath);
+  checks.gdprMigration = fs.existsSync(gdprMigrationPath);
+  checks.backupWorkflow = fs.existsSync(backupWorkflowPath);
+
+  try {
+    const pkgRaw = fs.readFileSync(path.join(projectRoot, "package.json"), "utf8");
+    const pkg = JSON.parse(pkgRaw) as { dependencies?: Record<string, string> };
+    checks.securityDeps = Boolean(pkg.dependencies?.helmet && pkg.dependencies?.["express-rate-limit"]);
+  } catch {
+    checks.securityDeps = false;
+  }
+
+  checks.requiredEnv = Boolean(process.env.DATABASE_URL && process.env.JWT_SECRET);
+
+  try {
+    await (db as any).$queryRaw`SELECT 1`;
+    checks.dbReachable = true;
+  } catch {
+    checks.dbReachable = false;
+  }
+
+  const completed = Object.values(checks).filter(Boolean).length;
+  const total = Object.values(checks).length;
+  const percent = Math.round((completed / total) * 100);
+  const status: "ok" | "degraded" = percent === 100 ? "ok" : "degraded";
+
+  res.status(status === "ok" ? 200 : 207).json({
+    status,
+    percent,
+    completed,
+    total,
+    timestamp: new Date().toISOString(),
+    checks,
+    nextActions: [
+      !checks.requiredEnv ? "Set DATABASE_URL and JWT_SECRET in environment" : null,
+      !checks.dbReachable ? "Verify PostgreSQL connectivity for runtime and prisma db push" : null,
+    ].filter(Boolean),
+  });
 });
 
 export default router;

--- a/Server/routes/postRoutes.ts
+++ b/Server/routes/postRoutes.ts
@@ -215,15 +215,27 @@ router.patch("/:id", async (req: Request, res: Response) => {
     if (!post) return res.status(404).json({ message: "Post not found" });
     if (post.authorId !== userId) return res.status(403).json({ message: "Not your post" });
 
-    const updated = await db.post.update({
-      where: { id: postId },
+    const updateResult = await db.post.updateMany({
+      where: { id: postId, tenantId, deletedAt: null },
       data:  { content: content.trim(), edited: true },
+    });
+
+    if (updateResult.count === 0) {
+      return res.status(404).json({ message: "Post not found" });
+    }
+
+    const updated = await db.post.findFirst({
+      where: { id: postId, tenantId, deletedAt: null },
       include: {
         author: { select: { id: true, name: true, email: true } },
         _count: { select: { likes: true, comments: true } },
         tags:   { include: { tag: true } },
       },
     });
+
+    if (!updated) {
+      return res.status(404).json({ message: "Post not found" });
+    }
 
     return res.json({
       ...updated,
@@ -255,10 +267,14 @@ router.delete("/:id", async (req: Request, res: Response) => {
     const canDelete = post.authorId === userId || ["owner", "admin"].includes(role);
     if (!canDelete) return res.status(403).json({ message: "Cannot delete this post" });
 
-    await db.post.update({
-      where: { id: postId },
+    const deleteResult = await db.post.updateMany({
+      where: { id: postId, tenantId, deletedAt: null },
       data:  { deletedAt: new Date() },
     });
+
+    if (deleteResult.count === 0) {
+      return res.status(404).json({ message: "Post not found" });
+    }
 
     return res.json({ message: "Post deleted" });
   } catch (err: any) {


### PR DESCRIPTION
### Motivation

- Add a lightweight audit endpoint to verify Phase 1 completion artifacts and runtime prerequisites for on-demand health/rollout checks. 
- Prevent accidental cross-tenant or stale-row updates when editing or deleting posts by requiring tenant-scoped conditions. 

### Description

- Add `fs` and `path` imports and implement `GET /health/phase1` that checks for specific migration files, backup workflow, required package dependencies, required environment variables (`DATABASE_URL`, `JWT_SECRET`), and DB reachability, returning a percent-complete report and `200` for full completion or `207` when degraded. 
- Compute a `checks` object and include `percent`, `completed`, `total`, `timestamp`, and `nextActions` in the response. 
- Update `PATCH /posts/:id` to use `db.post.updateMany` with `where: { id, tenantId, deletedAt: null }`, verify `updateResult.count`, re-fetch the updated post with `include` relations, and return a consistent response shape (counts and tag names). 
- Update `DELETE /posts/:id` to use `db.post.updateMany` with the same tenant-scoped `where`, verify `deleteResult.count`, and return appropriate `404` when no row was affected. 

### Testing

- Ran the full automated test suite with `npm test`, and it completed successfully. 
- Ran the TypeScript build with `npm run build` and the linter with `npm run lint`, and both succeeded. 
- Exercised the modified endpoints via automated route tests and the health check endpoint returns expected JSON structure under normal and degraded conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a113b9d20883219443c8c71f8e726b)